### PR TITLE
Add frame and names

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,16 @@ dependencies:
 const tracy = @import("tracy");
 
 fn function_i_wish_to_trace() void {
-    const t = tracy.trace(@src());
+    const t = tracy.trace(@src(), null);
     defer t.end();
     // ...
     // the rest of the function body
 }
 ```
+
+The second parameter to `trace` can be used to give a name to the zone,
+otherwise it will simply be the inferred function name and location in the
+source code.
 
 ```zig
 const tracy = @import("tracy");

--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ fn function_i_wish_to_trace() void {
 }
 ```
 
+```zig
+const tracy = @import("tracy");
+
+fn main() !void {
+    var quit = false;
+    while (!quit) {
+        const frame = tracy.frame(null);
+        defer frame.end();
+
+        // ...
+        // the rest of the loop
+    }
+}
+```
+
 ## Building
 ```
 $ zigmod fetch

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -5,6 +5,22 @@ pub const c = @cImport({
     @cInclude("TracyC.h");
 });
 
+pub const Frame = struct {
+    name: [*c]const u8,
+
+    pub fn end(self: Frame) void {
+        c.___tracy_emit_frame_mark_end(self.name);
+    }
+};
+
+pub fn frame(name: ?[*c]const u8) callconv(.Inline) Frame {
+    const f = Frame{
+        .name = if (name) |n| n else null,
+    };
+    c.___tracy_emit_frame_mark_start(f.name);
+    return f;
+}
+
 pub const Ctx = struct {
     c: c.___tracy_c_zone_context,
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -29,9 +29,9 @@ pub const Ctx = struct {
     }
 };
 
-pub fn trace(comptime src: std.builtin.SourceLocation) callconv(.Inline) Ctx {
+pub fn trace(comptime src: std.builtin.SourceLocation, name: ?[*c]const u8) callconv(.Inline) Ctx {
     const loc: c.___tracy_source_location_data = .{
-        .name = null,
+        .name = if (name) |n| n else null,
         .function = src.fn_name.ptr,
         .file = src.file.ptr,
         .line = src.line,

--- a/src/main.zig
+++ b/src/main.zig
@@ -5,7 +5,7 @@ const tracy = @import("tracy");
 var count: usize = 0;
 
 pub fn main() anyerror!void {
-    const t = tracy.trace(@src());
+    const t = tracy.trace(@src(), null);
     defer t.end();
 
     std.log.info("All your codebase are belong to us.", .{});


### PR DESCRIPTION
This adds support for `___tracy_emit_frame_mark` and named zones.

I'm not sure about the names and general code style in Zig, so please tell me if there's something to improve there.

I'm using this in my little [qck](https://github.com/heyLu/qck) experiment.  I initially wanted it because I have a very long loop inside a function and almost no function calls yet.

Here's how this looks inside tracy:

![2021-11-12-zig-tracy-with-stuff](https://user-images.githubusercontent.com/527119/141515215-45a72113-ada3-42bf-9dcd-14a2148803d6.png)

Thanks for making `zig-tracy`!
