### PR TITLE
fix dependencies attribute flavor so that @import("tracy") works

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Currently uses tracy v0.7.8
 Using the https://github.com/nektro/zigmod package manager.
 
 ```yml
-dependencies:
+root_dependencies:
   - src: git https://github.com/nektro/zig-tracy
 ```
 


### PR DESCRIPTION
if trying to add tracy to a main() like the second example, one gets an `error: unable to find 'tracy'` with the current zig.mod example.